### PR TITLE
Added Body and Content-Type options to the HTTP requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,19 +95,18 @@ func Run(ctx context.Context, config string) error {
 	default:
 		return fmt.Errorf("provided invalid command/http verb: %q", conf.Verb)
 	}
-	
-	if conf.ContentType == "empty"{
-		req, err := http.NewRequestWithContext(ctx, requestType, conf.URL, nil)
-		if err != nil {
-			return fmt.Errorf("encounted error while creating request: %v", err.Error())
-			}
-	}else{
-		body := []byte(conf.Body)
-		req, err := http.NewRequestWithContext(ctx, requestType, conf.URL, bytes.NewBuffer(body))
+	var req *http.Request
+	if conf.ContentType == "empty" {
+		req, err = http.NewRequestWithContext(ctx, requestType, conf.URL, nil)
 		if err != nil {
 			return fmt.Errorf("encounted error while creating request: %v", err.Error())
 		}
-		req.Header.Add("Content-Type",conf.ContentType)
+	} else {
+		req, err = http.NewRequestWithContext(ctx, requestType, conf.URL, bytes.NewBufferString(conf.Body))
+		if err != nil {
+			return fmt.Errorf("encounted error while creating request: %v", err.Error())
+		}
+		req.Header.Add("Content-Type", conf.ContentType)
 	}
 
 	tls_config := &tls.Config{InsecureSkipVerify: conf.Insecure}

--- a/main.go
+++ b/main.go
@@ -59,6 +59,18 @@ func Validate(config string) error {
 			return fmt.Errorf("invalid status code provided: %d", status_code)
 		}
 	}
+	
+	if conf.ContentType == "empty" && conf.Body != "" {
+		return fmt.Errorf("body must not be provided when using empty Content-Type; got: %v", conf.Body)
+	}
+
+	if conf.ContentType != "empty" && conf.Body == "" {
+		return fmt.Errorf("body must be provided when using non-empty Content-Type; got: %v", conf.Body)
+	}
+
+	if !slices.Contains([]string{"plain/text", "application/json", "x-www-form-urlencoded", "empty"}, conf.ContentType) {
+		return fmt.Errorf("invalid content type provided: %v", conf.ContentType)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Added a Content-Type and Body options to be used. The new options are not POST request exclusive. Under Content-Type there are new options of plain/text, application/json, x-www-urlencoded, and empty. 