### PR TITLE
Added a new functionality to add custom headers to checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# http with headers
+# http

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# http
+# http with headers

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scorify/http
 
-go 1.22.6
+go 1.24.0
 
 toolchain go1.22.7
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pmj1426/http-scorify
+module github.com/scorify/http
 
 go 1.24.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/scorify/http
+module github.com/pmj1426/http-scorify
 
 go 1.24.0
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/pmj1426/http-scorify
 
 go 1.24.0
 
-toolchain go1.22.7
-
 require github.com/scorify/schema v0.0.0

--- a/main.go
+++ b/main.go
@@ -61,12 +61,16 @@ func Validate(config string) error {
 		}
 	}
 
-	if !strings.Contains(conf.Headers, ":") && conf.Headers != "" {
-		return fmt.Errorf("header format must be \"header:value;header:value\" ; got: %v", conf.Headers)
-	}
-
-	if strings.Count(conf.Headers, ":") != 1 && !strings.Contains(conf.Headers, ";") {
-		return fmt.Errorf("header format must be \"header:value;header:value\" ; got: %v", conf.Headers)
+	if conf.Headers != "" {
+		for _, raw := range strings.Split(conf.Headers, ";") {
+			if raw == "" {
+				return fmt.Errorf("header format must be \"header:value;header:value\" ; got: %v", conf.Headers)
+			}
+			parts := strings.SplitN(raw, ":", 2)
+			if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+				return fmt.Errorf("header format must be \"header:value;header:value\" ; got: %v", conf.Headers)
+			}
+		}
 	}
 
 	if conf.ContentType == "empty" && conf.Body != "" {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -10,7 +11,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"bytes"
 
 	"github.com/scorify/schema"
 )
@@ -21,7 +21,8 @@ type Schema struct {
 	ExpectedOutput string `key:"expected_output"`
 	MatchType      string `key:"match_type" default:"statusCode" enum:"statusCode,substringMatch,exactMatch,regexMatch"`
 	Insecure       bool   `key:"insecure"`
-	Body	       string `key:"body"`
+	Headers        string `key:"headers"`
+	Body           string `key:"body"`
 	ContentType    string `key:"content_type" default:"empty" enum:"plain/text,application/json,x-www-form-urlencoded,empty"`
 }
 
@@ -59,7 +60,15 @@ func Validate(config string) error {
 			return fmt.Errorf("invalid status code provided: %d", status_code)
 		}
 	}
-	
+
+	if !strings.Contains(conf.Headers, ":") && conf.Headers != "" {
+		return fmt.Errorf("header format must be \"header:value;header:value\" ; got: %v", conf.Headers)
+	}
+
+	if strings.Count(conf.Headers, ":") != 1 && !strings.Contains(conf.Headers, ";") {
+		return fmt.Errorf("header format must be \"header:value;header:value\" ; got: %v", conf.Headers)
+	}
+
 	if conf.ContentType == "empty" && conf.Body != "" {
 		return fmt.Errorf("body must not be provided when using empty Content-Type; got: %v", conf.Body)
 	}
@@ -113,6 +122,14 @@ func Run(ctx context.Context, config string) error {
 		if err != nil {
 			return fmt.Errorf("encounted error while creating request: %v", err.Error())
 		}
+		if strings.Contains(conf.Headers, ";") {
+			for _, element := range strings.Split(conf.Headers, ";") {
+				req.Header.Add(strings.Split(element, ":")[0], strings.Split(element, ":")[1])
+			}
+		} else {
+			req.Header.Add(strings.Split(conf.Headers, ":")[0], strings.Split(conf.Headers, ":")[1])
+		}
+
 	} else {
 		req, err = http.NewRequestWithContext(ctx, requestType, conf.URL, bytes.NewBufferString(conf.Body))
 		if err != nil {


### PR DESCRIPTION
# Added Custom Header Option
Added option for users to add custom headers to HTTP checks.
|Problem|Fix|Files Changed|
|:---|:---|:---|
|Users were requesting adding headers to increase the scoring capabilities for more complex services.|Added the functionality to allow for custom headers to be added to the requests. This allows for greater use of the scoring engine for complex servicces that may use authorization tokens.|Changed main.go to added the Headers option to the struct and added validation checks to validate the input. Added lines to add the headers to the HTTP requests.|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable HTTP headers in request settings; specify as "key:value" with semicolon-separated entries. Headers are applied consistently across request flows, including when Content-Type is unset.
* **Bug Fixes / Validation**
  * Enforce header entry format to ensure valid "key:value" (semicolon-delimited list allowed).
* **Chores**
  * Toolchain upgraded to Go 1.24.0; module path updated.
* **Documentation**
  * README heading updated to reflect header support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->