### PR TITLE
Fixed Headers logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,13 +126,6 @@ func Run(ctx context.Context, config string) error {
 		if err != nil {
 			return fmt.Errorf("encounted error while creating request: %v", err.Error())
 		}
-		if strings.Contains(conf.Headers, ";") {
-			for _, element := range strings.Split(conf.Headers, ";") {
-				req.Header.Add(strings.Split(element, ":")[0], strings.Split(element, ":")[1])
-			}
-		} else {
-			req.Header.Add(strings.Split(conf.Headers, ":")[0], strings.Split(conf.Headers, ":")[1])
-		}
 
 	} else {
 		req, err = http.NewRequestWithContext(ctx, requestType, conf.URL, bytes.NewBufferString(conf.Body))
@@ -140,6 +133,14 @@ func Run(ctx context.Context, config string) error {
 			return fmt.Errorf("encounted error while creating request: %v", err.Error())
 		}
 		req.Header.Add("Content-Type", conf.ContentType)
+	}
+
+	if conf.Headers != "" {
+		for _, element := range strings.Split(conf.Headers, ";") {
+			req.Header.Add(strings.Split(element, ":")[0], strings.Split(element, ":")[1])
+		}
+	} else {
+		req.Header.Add(strings.Split(conf.Headers, ":")[0], strings.Split(conf.Headers, ":")[1])
 	}
 
 	tls_config := &tls.Config{InsecureSkipVerify: conf.Insecure}

--- a/main.go
+++ b/main.go
@@ -138,18 +138,19 @@ func Run(ctx context.Context, config string) error {
 	if conf.Headers != "" {
 		if strings.Contains(conf.Headers, ";") {
 			headers := strings.Split(conf.Headers, ";")
-			if len(headers)%2 == 0 {
-				return fmt.Errorf("header format must be \"header:value;header:value\" ; got: %v", conf.Headers)
-			}
 			for _, element := range headers {
-				req.Header.Add(strings.Split(element, ":")[0], strings.Split(element, ":")[1])
+				keyvalue := strings.Split(element, ":")
+				if len(keyvalue) != 2 {
+					return fmt.Errorf("header format must be \"header:value;header:value\" ; got: %v", conf.Headers)
+				}
+				req.Header.Add(keyvalue[0], keyvalue[1])
 			}
 		} else {
-			headers := strings.Split(conf.Headers, ";")
-			if len(headers)%2 == 0 {
+			keyvalue := strings.Split(conf.Headers, ":")
+			if len(keyvalue) != 2 {
 				return fmt.Errorf("header format must be \"header:value;header:value\" ; got: %v", conf.Headers)
 			}
-			req.Header.Add(headers[0], headers[1])
+			req.Header.Add(keyvalue[0], keyvalue[1])
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -137,11 +137,19 @@ func Run(ctx context.Context, config string) error {
 
 	if conf.Headers != "" {
 		if strings.Contains(conf.Headers, ";") {
-			for _, element := range strings.Split(conf.Headers, ";") {
+			headers := strings.Split(conf.Headers, ";")
+			if len(headers)%2 == 0 {
+				return fmt.Errorf("header format must be \"header:value;header:value\" ; got: %v", conf.Headers)
+			}
+			for _, element := range headers {
 				req.Header.Add(strings.Split(element, ":")[0], strings.Split(element, ":")[1])
 			}
 		} else {
-			req.Header.Add(strings.Split(conf.Headers, ":")[0], strings.Split(conf.Headers, ":")[1])
+			headers := strings.Split(conf.Headers, ";")
+			if len(headers)%2 == 0 {
+				return fmt.Errorf("header format must be \"header:value;header:value\" ; got: %v", conf.Headers)
+			}
+			req.Header.Add(headers[0], headers[1])
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -136,11 +136,13 @@ func Run(ctx context.Context, config string) error {
 	}
 
 	if conf.Headers != "" {
-		for _, element := range strings.Split(conf.Headers, ";") {
-			req.Header.Add(strings.Split(element, ":")[0], strings.Split(element, ":")[1])
+		if strings.Contains(conf.Headers, ";") {
+			for _, element := range strings.Split(conf.Headers, ";") {
+				req.Header.Add(strings.Split(element, ":")[0], strings.Split(element, ":")[1])
+			}
+		} else {
+			req.Header.Add(strings.Split(conf.Headers, ":")[0], strings.Split(conf.Headers, ":")[1])
 		}
-	} else {
-		req.Header.Add(strings.Split(conf.Headers, ":")[0], strings.Split(conf.Headers, ":")[1])
 	}
 
 	tls_config := &tls.Config{InsecureSkipVerify: conf.Insecure}


### PR DESCRIPTION
Originally the headers would not execute unless the ContentType field was set to empty and the Headers string contained a semi-colon. Moved the logic and made it so the Headers executes if not empty now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved header population to a single post-request-creation step so headers are applied consistently for empty and non-empty requests; public interfaces unchanged.

* **Bug Fixes**
  * Added strict header format validation: semicolon-separated entries must be header:value with exactly one colon; single entries must also follow header:value.
  * Returns explicit errors when header parts are malformed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->